### PR TITLE
The slack messages are using an outdated format and to get the inform…

### DIFF
--- a/src/aws_cloudwatch_alerting_lambda/aws_cloudwatch_alerting.py
+++ b/src/aws_cloudwatch_alerting_lambda/aws_cloudwatch_alerting.py
@@ -371,20 +371,17 @@ def config_custom_cloudwatch_alarm_notification(message, region, payload):
         cloudwatch_url + region + "#s=Alarms&alarm=" + alarm_name.replace(" ", "%20")
     )
 
-    colour = "warning"
     icon = ":warning:"
     slack_channel = slack_channel_main
 
     logger.info(
-        f'Set slack message variables", "severity": {severity}, "notification_type": {notification_type}, "alarm_name": {alarm_name}, "alarm_url": {alarm_url}, "colour": {colour}, "icon": {icon}, "slack_channel": {slack_channel}, "correlation_id": "{correlation_id}'
+        f'Set slack message variables", "severity": {severity}, "notification_type": {notification_type}, "alarm_name": {alarm_name}, "alarm_url": {alarm_url}, "icon": {icon}, "slack_channel": {slack_channel}, "correlation_id": "{correlation_id}'
     )
 
     if notification_type.lower() == "information":
         icon = ":information_source:"
-        colour = "good"
     elif notification_type.lower() == "error":
         icon = ":fire:"
-        colour = "danger"
         if severity.lower() == "high" or severity.lower() == "critical":
             slack_channel = slack_channel_critical
     elif severity.lower() == "critical":

--- a/src/aws_cloudwatch_alerting_lambda/aws_cloudwatch_alerting.py
+++ b/src/aws_cloudwatch_alerting_lambda/aws_cloudwatch_alerting.py
@@ -103,13 +103,12 @@ def decrypt(encrypted_url):
         )
 
 
-def config_notification(message, region):
+def config_notification(message, region, payload):
     dumped_message = get_escaped_json_string(message)
     logger.info(
         f'Processing config notification", "message": {dumped_message}, "region": {region}, "correlation_id": "{correlation_id}'
     )
 
-    states = {"COMPLIANT": "good", "NOT_APPLICABLE": "good", "NON_COMPLIANT": "danger"}
     no_emojis = {
         "COMPLIANT": "Compliant",
         "NOT_APPLICABLE": "N/A",
@@ -149,24 +148,23 @@ def config_notification(message, region):
         )
     )
 
-    return {
-        "color": states[message["newEvaluationResult"]["complianceType"]],
-        "fallback": "AWS Config Compliance Change detected " + config_rule_name,
-        "fields": [
-            {
-                "title": "AWS Config Compliance Rule [" + config_rule_name + "]",
-                "value": " has changed from ["
+    payload["text"] = "AWS Config Compliance Change detected " + config_rule_name
+    payload["blocks"] = [{
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": "AWS Config Compliance Rule [" + config_rule_name + "] has changed from ["
                 + no_emojis[config_old_state]
                 + "] to ["
                 + emojis[config_new_state]
                 + "]\nThis script can't tell if everything is compliant or not. For full details check the AWS Console: "
                 + config_url,
-            }
-        ],
-    }
+        }
+    }]
+    return payload
 
 
-def config_cloudwatch_event_notification(message, region):
+def config_cloudwatch_event_notification(message, region, payload):
     dumped_message = get_escaped_json_string(message)
     logger.info(
         f'Processing cloudwatch event notification", "message": {dumped_message}, "region": {region}, "correlation_id": "{correlation_id}'
@@ -295,35 +293,35 @@ def config_cloudwatch_event_notification(message, region):
         # we do not want to be alerted about any of these...
         quit()
     else:
-        return default_notification(message)
+        return default_notification(message, payload)
 
-    return {
-        "fallback": title,
-        "fields": [
-            {
-                "title": title,
-                "value": value
+    payload["text"] = title
+    payload["blocks"] = [{
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": value
                 + "\nFor full details check the AWS Console ["
                 + config_url
                 + "].",
-            }
-        ],
-    }
+        }
+    }]
+    return payload
 
 
-def config_cloudwatch_alarm_notification(message, region, prowler_slack_channel):
+def config_cloudwatch_alarm_notification(message, region, prowler_slack_channel, payload):
     dumped_message = get_escaped_json_string(message)
     logger.info(
         f'Processing cloudwatch notification", "message": {dumped_message}, "region": {region}, "prowler_slack_channel": {prowler_slack_channel}, "correlation_id": "{correlation_id}'
     )
 
     if "Namespace" in message and message["Namespace"] == "Prowler/Monitoring":
-        return (
-            prowler_slack_channel,
-            config_prowler_cloudwatch_alarm_notification(message, region),
-        )
+        payload = config_prowler_cloudwatch_alarm_notification(message, region, payload)
+        payload["channel"] = prowler_slack_channel
+    else:
+        payload = config_custom_cloudwatch_alarm_notification(message, region, payload)
 
-    return config_custom_cloudwatch_alarm_notification(message, region)
+    return payload
 
 
 def get_tags_for_cloudwatch_alarm(cw_client, alarm_arn):
@@ -338,7 +336,7 @@ def get_tags_for_cloudwatch_alarm(cw_client, alarm_arn):
     return tags["Tags"] if tags else []
 
 
-def config_custom_cloudwatch_alarm_notification(message, region):
+def config_custom_cloudwatch_alarm_notification(message, region, payload):
     dumped_message = get_escaped_json_string(message)
     logger.info(
         f'Processing custom cloudwatch notification", "message": {dumped_message}, "region": {region}, "correlation_id": "{correlation_id}'
@@ -406,11 +404,12 @@ def config_custom_cloudwatch_alarm_notification(message, region):
         f'Set trigger time", "trigger_time": {trigger_time}, "correlation_id": "{correlation_id}'
     )
 
-    return (
-        slack_channel,
-        {
-            "color": colour,
-            "fallback": title,
+    payload["channel"] = slack_channel
+    payload["text"] = title
+    payload["blocks"] = [{
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
             "fields": [
                 {"title": "AWS Console link", "value": alarm_url},
                 {
@@ -420,11 +419,12 @@ def config_custom_cloudwatch_alarm_notification(message, region):
                 {"title": "Severity", "value": severity},
                 {"title": "Type", "value": notification_type},
             ],
-        },
-    )
+        }
+    }]
+    return payload
 
 
-def config_prowler_cloudwatch_alarm_notification(message, region):
+def config_prowler_cloudwatch_alarm_notification(message, region, payload):
     dumped_message = get_escaped_json_string(message)
     logger.info(
         f'Processing prowler notification", "message": {dumped_message}, "region": {region}, "correlation_id": "{correlation_id}'
@@ -521,7 +521,7 @@ def config_prowler_cloudwatch_alarm_notification(message, region):
     }
 
 
-def guardduty_notification(message, region):
+def guardduty_notification(message, region, payload):
     dumped_message = get_escaped_json_string(message)
     logger.info(
         f'Processing guard duty notification", "message": {dumped_message}, "region": {region}, "correlation_id": "{correlation_id}'
@@ -540,13 +540,12 @@ def guardduty_notification(message, region):
         + "#/findings"
     )
 
-    return {
-        "color": "danger",
-        "fallback": "AWS GuardDuty Finding Type [" + gd_finding_detail_type + "]",
-        "fields": [
-            {
-                "title": "AWS GuardDuty Finding.",
-                "value": "Finding of type ["
+    payload["text"] = "AWS GuardDuty Finding Type [" + gd_finding_detail_type + "]"
+    payload["blocks"] = [{
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": "Finding of type ["
                 + gd_finding_detail_type
                 + "] due to an action of type ["
                 + gd_finding_detail_service_action_type
@@ -554,19 +553,17 @@ def guardduty_notification(message, region):
                 + gd_finding_detail_resource_type
                 + "].\nFor full details check the AWS Console ["
                 + gd_url
-                + "].",
-            }
-        ],
-    }
+                + "]."
+        }
+    }]
+    return payload
 
 
-def app_notification(slack_message, region):
+def app_notification(slack_message, region, payload):
     dumped_slack_message = get_escaped_json_string(slack_message)
     logger.info(
         f'Processing app notification", "slack_message": {dumped_slack_message}, "correlation_id": "{correlation_id}'
     )
-
-    states = {"INFO": "good", "ERROR": "danger"}
 
     recognised_apps = {
         "Security": "",
@@ -594,31 +591,38 @@ def app_notification(slack_message, region):
         f'Created app notification", "app_function_message": {dumped_app_function_message}, "correlation_id": "{correlation_id}'
     )
 
-    return {
-        "color": states[app_function_message_type],
-        "fallback": title,
-        "fields": [
-            {
-                "title": title,
-                "value": app_function
-                + " "
-                + app_function_message_type
-                + ": "
-                + app_function_message,
-            }
-        ],
-    }
+    payload["text"] = title
+    payload["blocks"] = [{
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": f"{app_function} {app_function_message_type}: {app_function_message}"
+        }
+    }]
+    return payload
 
 
-def default_notification(message):
+def default_notification(message, payload):
     dumped_message = get_escaped_json_string(message)
     logger.info(
         f'Processing default notification", "message": {dumped_message}, "correlation_id": "{correlation_id}'
     )
-    return {
-        "fallback": "A new message",
-        "fields": [{"title": "Message", "value": json.dumps(message), "short": False}],
-    }
+    payload["text"] = "Unidentified notification"
+    payload["blocks"] = [{
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": "A new unindentified message"
+        },
+        "fields": [
+            {
+                "type": "plain_text",
+                "emoji": false,
+                "text": "dumped_message"
+            }
+        ]
+    }]
+    return payload
 
 
 # Send a message to a slack channel
@@ -639,7 +643,6 @@ def notify_slack(message, region):
         payload = {
             "channel": slack_channel,
             "username": slack_username,
-            "attachments": [],
         }
 
         dumped_payload = get_escaped_json_string(payload)
@@ -647,7 +650,7 @@ def notify_slack(message, region):
             f'Created initial app slack payload", "payload": {dumped_payload}, "app_slack_url": {slack_url}, "app_slack_channel": {slack_channel}, "app_slack_username": {slack_username}, "correlation_id": "{correlation_id}'
         )
 
-        payload["attachments"].append(app_notification(message, region))
+        payload = app_notification(message, region, payload)
     else:
         # this is a status update from AWS...
 
@@ -664,7 +667,6 @@ def notify_slack(message, region):
         payload = {
             "channel": slack_channel,
             "username": slack_username,
-            "attachments": [],
         }
 
         dumped_payload = get_escaped_json_string(payload)
@@ -673,10 +675,10 @@ def notify_slack(message, region):
         )
 
         if "detail-type" in message and message["detail-type"] == "GuardDuty Finding":
-            payload["attachments"].append(guardduty_notification(message, region))
+            payload = guardduty_notification(message, region, payload)
         elif "configRuleName" in message:
             # this is a compliance/non-compliance AWS Config message...
-            payload["attachments"].append(config_notification(message, region))
+            payload = config_notification(message, region, payload)
         elif (
             "messageType" in message
             and message["messageType"] == "ConfigurationItemChangeNotification"
@@ -688,23 +690,16 @@ def notify_slack(message, region):
             quit()
         elif "messageType" in message:
             # assume this is another type of AWS Config CloudWatch Event that we do not see so frequently...
-            payload["attachments"].append(
-                config_cloudwatch_event_notification(message, region)
-            )
+            payload = config_cloudwatch_event_notification(message, region, payload)
         elif "AlarmName" in message:
             if os.environ["USE_AWS_SLACK_CHANNELS"].lower() == "true":
-                (channel, attachment) = config_cloudwatch_alarm_notification(
-                    message, region, os.environ["AWS_SLACK_CHANNEL_MAIN"]
+                payload = config_cloudwatch_alarm_notification(
+                    message, region, os.environ["AWS_SLACK_CHANNEL_MAIN"], payload
                 )
-                payload["channel"] = channel
-                payload["attachments"].append(attachment)
             else:
-                payload["attachments"].append(
-                    config_prowler_cloudwatch_alarm_notification(message, region)
-                )
+                payload = config_prowler_cloudwatch_alarm_notification(message, region, payload)
         else:
-            payload["text"] = "Unidentified notification"
-            payload["attachments"].append(default_notification(message))
+            payload = default_notification(message, payload)
 
     dumped_payload = get_escaped_json_string(payload)
     logger.info(

--- a/tests/test_aws_cloudwatch_alerting.py
+++ b/tests/test_aws_cloudwatch_alerting.py
@@ -50,18 +50,19 @@ class TestRetriever(unittest.TestCase):
         prowler_cw_mock,
     ):
         event = {"Namespace": "Prowler/Monitoring"}
+        payload = {}
+        return_payload = { "channel": slack_channel_main }
 
-        (
-            actual_slack_channel,
-            actual_message,
-        ) = aws_cloudwatch_alerting.config_cloudwatch_alarm_notification(
-            event, region, slack_channel_main
+        prowler_cw_mock.return_value = return_payload
+
+        actual_message = aws_cloudwatch_alerting.config_cloudwatch_alarm_notification(
+            event, region, slack_channel_main, payload
         )
 
-        prowler_cw_mock.assert_called_once_with(event, region)
+        prowler_cw_mock.assert_called_once_with(event, region, payload)
         custom_cw_mock.assert_not_called()
 
-        self.assertEqual(actual_slack_channel, slack_channel_main)
+        self.assertEqual(actual_message["channel"], slack_channel_main)
 
     @mock.patch(
         "aws_cloudwatch_alerting_lambda.aws_cloudwatch_alerting.config_prowler_cloudwatch_alarm_notification"
@@ -75,20 +76,19 @@ class TestRetriever(unittest.TestCase):
         prowler_cw_mock,
     ):
         event = {"Namespace": "Test/Monitoring"}
+        payload = {}
+        return_payload = { "channel": slack_channel_critical }
 
-        custom_cw_mock.return_value = (slack_channel_critical, {"Test": "test"})
+        custom_cw_mock.return_value = return_payload
 
-        (
-            actual_slack_channel,
-            actual_message,
-        ) = aws_cloudwatch_alerting.config_cloudwatch_alarm_notification(
-            event, region, slack_channel_main
+        actual_message = aws_cloudwatch_alerting.config_cloudwatch_alarm_notification(
+            event, region, slack_channel_main, payload
         )
 
         prowler_cw_mock.assert_not_called()
-        custom_cw_mock.assert_called_once_with(event, region)
+        custom_cw_mock.assert_called_once_with(event, region, payload)
 
-        self.assertEqual(actual_slack_channel, slack_channel_critical)
+        self.assertEqual(actual_message["channel"], slack_channel_critical)
 
     @mock.patch(
         "aws_cloudwatch_alerting_lambda.aws_cloudwatch_alerting.config_prowler_cloudwatch_alarm_notification"
@@ -102,20 +102,19 @@ class TestRetriever(unittest.TestCase):
         prowler_cw_mock,
     ):
         event = {"Test": "Test/Monitoring"}
+        payload = {}
+        return_payload = { "channel": slack_channel_critical }
 
-        custom_cw_mock.return_value = (slack_channel_critical, {"Test": "test"})
+        custom_cw_mock.return_value = return_payload
 
-        (
-            actual_slack_channel,
-            actual_message,
-        ) = aws_cloudwatch_alerting.config_cloudwatch_alarm_notification(
-            event, region, slack_channel_main
+        actual_message = aws_cloudwatch_alerting.config_cloudwatch_alarm_notification(
+            event, region, slack_channel_main, payload
         )
 
         prowler_cw_mock.assert_not_called()
-        custom_cw_mock.assert_called_once_with(event, region)
+        custom_cw_mock.assert_called_once_with(event, region, payload)
 
-        self.assertEqual(actual_slack_channel, slack_channel_critical)
+        self.assertEqual(actual_message["channel"], slack_channel_critical)
 
     @mock.patch(
         "aws_cloudwatch_alerting_lambda.aws_cloudwatch_alerting.config_prowler_cloudwatch_alarm_notification"
@@ -129,20 +128,19 @@ class TestRetriever(unittest.TestCase):
         prowler_cw_mock,
     ):
         event = {"Namespace": ""}
+        payload = {}
+        return_payload = { "channel": slack_channel_critical }
 
-        custom_cw_mock.return_value = (slack_channel_critical, {"Test": "test"})
+        custom_cw_mock.return_value = return_payload
 
-        (
-            actual_slack_channel,
-            actual_message,
-        ) = aws_cloudwatch_alerting.config_cloudwatch_alarm_notification(
-            event, region, slack_channel_main
+        actual_message = aws_cloudwatch_alerting.config_cloudwatch_alarm_notification(
+            event, region, slack_channel_main, payload
         )
 
         prowler_cw_mock.assert_not_called()
-        custom_cw_mock.assert_called_once_with(event, region)
+        custom_cw_mock.assert_called_once_with(event, region, payload)
 
-        self.assertEqual(actual_slack_channel, slack_channel_critical)
+        self.assertEqual(actual_message["channel"], slack_channel_critical)
 
     @mock.patch(
         "aws_cloudwatch_alerting_lambda.aws_cloudwatch_alerting.config_prowler_cloudwatch_alarm_notification"
@@ -156,20 +154,19 @@ class TestRetriever(unittest.TestCase):
         prowler_cw_mock,
     ):
         event = {"Namespace": None}
+        payload = {}
+        return_payload = { "channel": slack_channel_critical }
 
-        custom_cw_mock.return_value = (slack_channel_critical, {"Test": "test"})
+        custom_cw_mock.return_value = return_payload
 
-        (
-            actual_slack_channel,
-            actual_message,
-        ) = aws_cloudwatch_alerting.config_cloudwatch_alarm_notification(
-            event, region, slack_channel_main
+        actual_message = aws_cloudwatch_alerting.config_cloudwatch_alarm_notification(
+            event, region, slack_channel_main, payload
         )
 
         prowler_cw_mock.assert_not_called()
-        custom_cw_mock.assert_called_once_with(event, region)
+        custom_cw_mock.assert_called_once_with(event, region, payload)
 
-        self.assertEqual(actual_slack_channel, slack_channel_critical)
+        self.assertEqual(actual_message["channel"], slack_channel_critical)
 
     def test_get_tags_for_cloudwatch_alarm_calls_aws_correctly(
         self,
@@ -196,7 +193,6 @@ class TestRetriever(unittest.TestCase):
             "low",
             "information",
             icon_information_source,
-            "good",
             slack_channel_main,
         )
 
@@ -215,7 +211,6 @@ class TestRetriever(unittest.TestCase):
             "medium",
             "information",
             icon_information_source,
-            "good",
             slack_channel_main,
         )
 
@@ -234,7 +229,6 @@ class TestRetriever(unittest.TestCase):
             "high",
             "information",
             icon_information_source,
-            "good",
             slack_channel_main,
         )
 
@@ -253,7 +247,6 @@ class TestRetriever(unittest.TestCase):
             "critical",
             "information",
             icon_information_source,
-            "good",
             slack_channel_main,
         )
 
@@ -272,7 +265,6 @@ class TestRetriever(unittest.TestCase):
             "low",
             "warning",
             icon_warning,
-            "warning",
             slack_channel_main,
         )
 
@@ -291,7 +283,6 @@ class TestRetriever(unittest.TestCase):
             "medium",
             "warning",
             icon_warning,
-            "warning",
             slack_channel_main,
         )
 
@@ -310,7 +301,6 @@ class TestRetriever(unittest.TestCase):
             "high",
             "warning",
             icon_warning,
-            "warning",
             slack_channel_main,
         )
 
@@ -329,7 +319,6 @@ class TestRetriever(unittest.TestCase):
             "critical",
             "warning",
             icon_warning,
-            "warning",
             slack_channel_critical,
         )
 
@@ -348,7 +337,6 @@ class TestRetriever(unittest.TestCase):
             "low",
             "error",
             icon_fire,
-            "danger",
             slack_channel_main,
         )
 
@@ -367,7 +355,6 @@ class TestRetriever(unittest.TestCase):
             "medium",
             "error",
             icon_fire,
-            "danger",
             slack_channel_main,
         )
 
@@ -386,7 +373,6 @@ class TestRetriever(unittest.TestCase):
             "high",
             "error",
             icon_fire,
-            "danger",
             slack_channel_critical,
         )
 
@@ -405,7 +391,6 @@ class TestRetriever(unittest.TestCase):
             "critical",
             "error",
             icon_fire,
-            "danger",
             slack_channel_critical,
         )
 
@@ -424,7 +409,6 @@ class TestRetriever(unittest.TestCase):
             "NOT_SET",
             "NOT_SET",
             icon_warning,
-            "warning",
             slack_channel_main,
         )
 
@@ -443,7 +427,6 @@ class TestRetriever(unittest.TestCase):
             "test",
             "test",
             icon_warning,
-            "warning",
             slack_channel_main,
         )
 
@@ -467,32 +450,31 @@ class TestRetriever(unittest.TestCase):
         aws_cloudwatch_alerting.get_tags_for_cloudwatch_alarm = tags_mock
         aws_cloudwatch_alerting.get_tags_for_cloudwatch_alarm.return_value = tags
 
-        (
-            actual_slack_channel,
-            actual_attachment,
-        ) = aws_cloudwatch_alerting.config_custom_cloudwatch_alarm_notification(
-            alarm, region
+        actual_payload = aws_cloudwatch_alerting.config_custom_cloudwatch_alarm_notification(
+            alarm, region, {}
         )
         tags_mock.assert_called_once_with(mock.ANY, alarm_arn)
 
-        expected_attachment = {
-            "color": "warning",
-            "fallback": f':warning: *TEST_ENVIRONMENT*: "_test_alarm name_" in eu-test-2',
-            "fields": [
-                {
-                    "title": attachment_title_link_field,
-                    "value": expected_cloudwatch_url,
-                },
-                {
-                    "title": trigger_time_field_title,
-                    "value": state_updated_timestamp_string,
-                },
-                {"title": severity_field_title, "value": "NOT_SET"},
-                {"title": type_field_title, "value": "NOT_SET"},
-            ],
+        expected_payload = {
+            "channel": slack_channel_main,
+            "text": f':warning: *TEST_ENVIRONMENT*: "_test_alarm name_" in eu-test-2',
+            "blocks": [{
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "fields": [
+                        {"title": attachment_title_link_field, "value": expected_cloudwatch_url},
+                        {
+                            "title": trigger_time_field_title,
+                            "value": state_updated_timestamp_string,
+                        },
+                        {"title": severity_field_title, "value": "NOT_SET"},
+                        {"title": type_field_title, "value": "NOT_SET"},
+                    ],
+                }
+            }]
         }
-        self.assertEqual(actual_slack_channel, slack_channel_main)
-        self.assertEqual(expected_attachment, actual_attachment)
+        self.assertEqual(expected_payload, actual_payload)
 
     @mock.patch(
         "aws_cloudwatch_alerting_lambda.aws_cloudwatch_alerting.get_tags_for_cloudwatch_alarm"
@@ -517,32 +499,31 @@ class TestRetriever(unittest.TestCase):
         aws_cloudwatch_alerting.get_tags_for_cloudwatch_alarm = tags_mock
         aws_cloudwatch_alerting.get_tags_for_cloudwatch_alarm.return_value = tags
 
-        (
-            actual_slack_channel,
-            actual_attachment,
-        ) = aws_cloudwatch_alerting.config_custom_cloudwatch_alarm_notification(
-            alarm, region
+        actual_payload = aws_cloudwatch_alerting.config_custom_cloudwatch_alarm_notification(
+            alarm, region, {}
         )
         tags_mock.assert_called_once_with(mock.ANY, alarm_arn)
 
-        expected_attachment = {
-            "color": "warning",
-            "fallback": f':warning: *TEST_ENVIRONMENT*: "_test_alarm name_" in eu-test-2',
-            "fields": [
-                {
-                    "title": attachment_title_link_field,
-                    "value": expected_cloudwatch_url,
-                },
-                {
-                    "title": trigger_time_field_title,
-                    "value": state_updated_timestamp_string,
-                },
-                {"title": severity_field_title, "value": "NOT_SET"},
-                {"title": type_field_title, "value": "NOT_SET"},
-            ],
+        expected_payload = {
+            "channel": slack_channel_main,
+            "text": f':warning: *TEST_ENVIRONMENT*: "_test_alarm name_" in eu-test-2',
+            "blocks": [{
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "fields": [
+                        {"title": attachment_title_link_field, "value": expected_cloudwatch_url},
+                        {
+                            "title": trigger_time_field_title,
+                            "value": state_updated_timestamp_string,
+                        },
+                        {"title": severity_field_title, "value": "NOT_SET"},
+                        {"title": type_field_title, "value": "NOT_SET"},
+                    ],
+                }
+            }]
         }
-        self.assertEqual(actual_slack_channel, slack_channel_main)
-        self.assertEqual(expected_attachment, actual_attachment)
+        self.assertEqual(expected_payload, actual_payload)
 
     @mock.patch(
         "aws_cloudwatch_alerting_lambda.aws_cloudwatch_alerting.get_tags_for_cloudwatch_alarm"
@@ -567,32 +548,31 @@ class TestRetriever(unittest.TestCase):
         aws_cloudwatch_alerting.get_tags_for_cloudwatch_alarm = tags_mock
         aws_cloudwatch_alerting.get_tags_for_cloudwatch_alarm.return_value = tags
 
-        (
-            actual_slack_channel,
-            actual_attachment,
-        ) = aws_cloudwatch_alerting.config_custom_cloudwatch_alarm_notification(
-            alarm, region
+        actual_payload = aws_cloudwatch_alerting.config_custom_cloudwatch_alarm_notification(
+            alarm, region, {}
         )
         tags_mock.assert_called_once_with(mock.ANY, alarm_arn)
 
-        expected_attachment = {
-            "color": "warning",
-            "fallback": f':warning: *TEST_ENVIRONMENT*: "_test_alarm name_" in eu-test-2',
-            "fields": [
-                {
-                    "title": attachment_title_link_field,
-                    "value": expected_cloudwatch_url,
-                },
-                {
-                    "title": trigger_time_field_title,
-                    "value": state_updated_timestamp_string,
-                },
-                {"title": severity_field_title, "value": "NOT_SET"},
-                {"title": type_field_title, "value": "NOT_SET"},
-            ],
+        expected_payload = {
+            "channel": slack_channel_main,
+            "text": f':warning: *TEST_ENVIRONMENT*: "_test_alarm name_" in eu-test-2',
+            "blocks": [{
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "fields": [
+                        {"title": attachment_title_link_field, "value": expected_cloudwatch_url},
+                        {
+                            "title": trigger_time_field_title,
+                            "value": state_updated_timestamp_string,
+                        },
+                        {"title": severity_field_title, "value": "NOT_SET"},
+                        {"title": type_field_title, "value": "NOT_SET"},
+                    ],
+                }
+            }]
         }
-        self.assertEqual(actual_slack_channel, slack_channel_main)
-        self.assertEqual(expected_attachment, actual_attachment)
+        self.assertEqual(expected_payload, actual_payload)
 
 
 def custom_cloudwatch_alarm_notification_returns_right_values(
@@ -603,7 +583,6 @@ def custom_cloudwatch_alarm_notification_returns_right_values(
     expected_severity,
     expected_type,
     expected_icon,
-    expected_colour,
     expected_slack_channel,
 ):
     self.maxDiff = None
@@ -622,32 +601,32 @@ def custom_cloudwatch_alarm_notification_returns_right_values(
     aws_cloudwatch_alerting.get_tags_for_cloudwatch_alarm = tags_mock
     aws_cloudwatch_alerting.get_tags_for_cloudwatch_alarm.return_value = tags
 
-    (
-        actual_slack_channel,
-        actual_attachment,
-    ) = aws_cloudwatch_alerting.config_custom_cloudwatch_alarm_notification(
-        alarm, region
+    actual_payload = aws_cloudwatch_alerting.config_custom_cloudwatch_alarm_notification(
+        alarm, region, {}
     )
     tags_mock.assert_called_once_with(mock.ANY, alarm_arn)
 
-    expected_attachment = {
-        "color": expected_colour,
-        "fallback": f'{expected_icon} *TEST_ENVIRONMENT*: "_test_alarm name_" in eu-test-2',
-        "fields": [
-            {
-                "title": attachment_title_link_field,
-                "value": expected_cloudwatch_url,
-            },
-            {
-                "title": trigger_time_field_title,
-                "value": state_updated_timestamp_string,
-            },
-            {"title": severity_field_title, "value": expected_severity},
-            {"title": type_field_title, "value": expected_type},
-        ],
+    expected_payload = {
+        "channel": expected_slack_channel,
+        "text": f'{expected_icon} *TEST_ENVIRONMENT*: "_test_alarm name_" in eu-test-2',
+        "blocks": [{
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "fields": [
+                    {"title": attachment_title_link_field, "value": expected_cloudwatch_url},
+                    {
+                        "title": trigger_time_field_title,
+                        "value": state_updated_timestamp_string,
+                    },
+                    {"title": severity_field_title, "value": expected_severity},
+                    {"title": type_field_title, "value": expected_type},
+                ],
+            }
+        }]
     }
-    self.assertEqual(actual_slack_channel, expected_slack_channel)
-    self.assertEqual(expected_attachment, actual_attachment)
+
+    self.assertEqual(expected_payload, actual_payload)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The slack messages are using an outdated format and to get the information we want have to be converted to using the new block format, so have done that with all the payloads