### PR TITLE
Allow us to pass in custom notifications that go to slack via an sqs …

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If the message has the `AlarmName` field it is a cloudwatch alarm notification. 
 
 If the message has the `Namespace` field and its value is set to `Prowler/Monitoring` then the message is assumed to be from the Prowler monitoring that is set up. In this case, the message is processed with a title of the name of the monitoring alert triggered and a URL to go to the alert directly is generated and set in the slack message.
 
-#### Custom alarms
+#### Custom cloudwatch alarms
 
 Without the `Namespace` field or if it is set to a different value, then the message is treated differently. The title will be set as the following:
 
@@ -112,6 +112,27 @@ If this application is going to be used to receive `app` notification types (see
 * `APP_INFO_SLACK_CHANNEL` (required if app notications needed) -> The name of the slack channel to send app notifications to
 * `APP_INFO_SLACK_USERNAME` (required if app notications needed) -> The username used for posting app notifications, can be anything
 * `APP_INFO_SLACK_ICON_EMOJI` (optional) -> The icon name used for app notifications, defaults to `:aws:`
+
+### Custom notifications
+
+If the message doesn't meet any of the conditions to be one of the types above, then it is treated as a custom notification. This enables anyone to log notifications with the right message to the SQS queues that are subscribed by this lambda. The following is an example message to send where the values describe what they can be:
+
+```
+{
+    "severity": "Critical" #Can be Critical, High, Medium or Low and defaults to "Medium"
+    "notification_type": "Error" #Can be Error, Warning or Information and defaults to Warning
+    "slack_username": "PDM Alerts" #Username for slack message and defaults to "AWS DataWorks Service Alerts - {environment_name}"
+    "active_days": "Monday" #See "Custom alarm tags" above (default is "NOT_SET")
+    "do_not_alert_before": "0700" #See "Custom alarm tags" above (default is "NOT_SET")
+    "do_not_alert_after": "1900" #See "Custom alarm tags" above (default is "NOT_SET")
+    "icon_override": ":aws:" #Slack text to create icon emoji for the message, default is to work out an icon from severity and notification_type
+    "slack_channel_override": "aws-dataworks-critical-alerts" #Slack channel name for the message, default is to work out an icon from severity and notification_type
+    "log_with_here": "true" #If "true" then adds @here to the slack message
+    "title_text": "HTME Export completed" #Custom text for the alert, defaults to "NOT_SET"
+}
+```
+
+The defaults allow for SQS messages with incorrect format to still log to slack so we can see where there are issues.
 
 ## Tests
 

--- a/src/aws_cloudwatch_alerting_lambda/aws_cloudwatch_alerting.py
+++ b/src/aws_cloudwatch_alerting_lambda/aws_cloudwatch_alerting.py
@@ -308,7 +308,7 @@ def config_cloudwatch_event_notification(message, region, payload):
         # we do not want to be alerted about any of these...
         quit()
     else:
-        return default_notification(message, payload)
+        return custom_notification(message, region, payload)
 
     payload["blocks"] = [
         {
@@ -883,23 +883,130 @@ def app_notification(slack_message, region, payload):
     return payload
 
 
-def default_notification(message, payload):
+def custom_notification(message, region, payload):
+    global date_format_display
+
     dumped_message = get_escaped_json_string(message)
     logger.info(
-        f'Processing default notification", "dumped_message": {dumped_message}, "correlation_id": "{correlation_id}'
+        f'Processing custom notification", "dumped_message": {dumped_message}, "correlation_id": "{correlation_id}", "region": "{region}'
     )
-    payload["blocks"] = [
+
+    tags = []
+    keys = ["active_days", "do_not_alert_before", "do_not_alert_after"]
+    for key in keys:
+        if key in message:
+            tags.append({"Key": key, "Value": message[key]})
+
+    if is_alarm_suppressed(tags, date.today(), datetime.now()):
+        logger.info(
+            f'Exiting script normally due to suppressed alarm", "correlation_id": "{correlation_id}'
+        )
+        sys.exit(0)
+
+    environment_name = os.environ["AWS_ENVIRONMENT"]
+    slack_channel_main = os.environ["AWS_SLACK_CHANNEL_MAIN"]
+    slack_channel_critical = os.environ["AWS_SLACK_CHANNEL_CRITICAL"]
+
+    active_days = message["active_days"] if "active_days" in message else "NOT_SET"
+    do_not_alert_before = (
+        message["do_not_alert_before"]
+        if "do_not_alert_before" in message
+        else "NOT_SET"
+    )
+    do_not_alert_after = (
+        message["do_not_alert_after"] if "do_not_alert_after" in message else "NOT_SET"
+    )
+    logger.info(
+        f'Set slack message suppression overrides", "active_days": "{active_days}", "do_not_alert_before": "{do_not_alert_before}", "do_not_alert_after": "{do_not_alert_after}", "correlation_id": "{correlation_id}'
+    )
+
+    severity = message["severity"] if "severity" in message else "Medium"
+    notification_type = (
+        message["notification_type"] if "notification_type" in message else "Warning"
+    )
+    slack_username = (
+        message["slack_username"]
+        if "slack_username" in message
+        else f"AWS DataWorks Service Alerts - {environment_name}"
+    )
+    icon_override = (
+        message["icon_override"] if "icon_override" in message else "NOT_SET"
+    )
+    slack_channel_override = (
+        message["slack_channel_override"]
+        if "slack_channel_override" in message
+        else "NOT_SET"
+    )
+    log_with_here = (
+        message["log_with_here"] if "log_with_here" in message else "NOT_SET"
+    )
+    title_text = message["title_text"] if "title_text" in message else "NOT_SET"
+
+    icon = ":warning:"
+    here = ""
+    slack_channel = slack_channel_main
+
+    if icon_override != "NOT_SET":
+        icon = icon_override
+    elif notification_type.lower() == "information":
+        icon = ":information_source:"
+    elif notification_type.lower() == "error":
+        icon = ":fire:"
+
+    if slack_channel_override != "NOT_SET":
+        slack_channel = slack_channel_override
+    elif notification_type.lower() == "error":
+        if severity.lower() == "high" or severity.lower() == "critical":
+            slack_channel = slack_channel_critical
+    elif severity.lower() == "critical":
+        slack_channel = slack_channel_critical
+
+    trigger_time = datetime.now().strftime(date_format_display)
+
+    logger.info(
+        f'Set slack message variables", "severity": "{severity}", "notification_type": "{notification_type}", "slack_username": "{slack_username}", "trigger_time": "{trigger_time}", "icon": "{icon}", "slack_channel": "{slack_channel}", "correlation_id": "{correlation_id}'
+    )
+
+    if log_with_here.lower() == "true":
+        here = "@here "
+
+    title = f'{here}*{environment_name.upper()}*: "_{title_text}_" in {region}'
+    logger.info(f'Set title", "title": "{title}", "correlation_id": "{correlation_id}')
+
+    payload["channel"] = slack_channel
+    blocks = []
+    blocks.append(
         {
             "type": "section",
-            "text": {"type": "mrkdwn", "text": "Unindentified message"},
-        },
+            "text": {
+                "type": "mrkdwn",
+                "text": title,
+            },
+        }
+    )
+
+    payload["username"] = slack_username
+    payload["icon_emoji"] = icon
+    blocks.append(
         {
             "type": "context",
             "elements": [
-                {"type": "plain_text", "text": f"*Dumped message*: {dumped_message}"}
+                {"type": "mrkdwn", "text": f"*Severity*: {severity}"},
+                {"type": "mrkdwn", "text": f"*Type*: {notification_type}"},
+                {"type": "mrkdwn", "text": f"*Active days*: {active_days}"},
+                {
+                    "type": "mrkdwn",
+                    "text": f"*Suppress before*: {do_not_alert_before}",
+                },
+                {
+                    "type": "mrkdwn",
+                    "text": f"*Suppress after*: {do_not_alert_after}",
+                },
             ],
-        },
-    ]
+        }
+    )
+
+    payload["blocks"] = blocks
     return payload
 
 
@@ -985,7 +1092,7 @@ def notify_slack(message, region):
                     message, region, payload
                 )
         else:
-            payload = default_notification(message, payload)
+            payload = custom_notification(message, region, payload)
 
     if "blocks" in payload:
         payload["blocks"].insert(0, {"type": "divider"})

--- a/src/aws_cloudwatch_alerting_lambda/aws_cloudwatch_alerting.py
+++ b/src/aws_cloudwatch_alerting_lambda/aws_cloudwatch_alerting.py
@@ -16,6 +16,7 @@ date_format = "%Y-%m-%dT%H:%M:%S.%f%z"
 date_format_display = "%Y-%m-%dT%H:%M:%S"
 log_level = os.environ["LOG_LEVEL"] if "LOG_LEVEL" in os.environ else "INFO"
 correlation_id = str(uuid.uuid4())
+information_source_icon = ":information_source:"
 
 
 # Initialise logging
@@ -513,7 +514,7 @@ def config_custom_cloudwatch_alarm_notification(message, region, payload):
     )
 
     if notification_type.lower() == "information":
-        icon = ":information_source:"
+        icon = information_source_icon
     elif notification_type.lower() == "error":
         icon = ":fire:"
         if severity.lower() == "high" or severity.lower() == "critical":
@@ -728,7 +729,7 @@ def config_prowler_cloudwatch_alarm_notification(message, region, payload):
         cloudwatch_metric_filter = cloudwatch_metric_filters[alarm_name]["filter"]
         severity = cloudwatch_metric_filters[alarm_name]["severity"]
         if severity.lower() == "low":
-            icon = ":information_source:"
+            icon = information_source_icon
         elif severity.lower() == "medium":
             icon = ":closed_lock_with_key:"
         elif severity.lower() == "high":
@@ -949,7 +950,7 @@ def custom_notification(message, region, payload):
     if icon_override != "NOT_SET":
         icon = icon_override
     elif notification_type.lower() == "information":
-        icon = ":information_source:"
+        icon = information_source_icon
     elif notification_type.lower() == "error":
         icon = ":fire:"
 

--- a/tests/test_aws_cloudwatch_alerting.py
+++ b/tests/test_aws_cloudwatch_alerting.py
@@ -37,6 +37,8 @@ state_updated_output_string = "2020-12-22T12:21:58"
 slack_channel_main = "test_slack_channel_main"
 slack_channel_critical = "test_slack_channel_critical"
 aws_environment = "test_environment"
+test_title = "AWS DataWorks Service Alerts - test_environment"
+aws_icon = ":aws:"
 
 icon_information_source = ":information_source:"
 icon_warning = ":warning:"
@@ -1340,7 +1342,7 @@ class TestRetriever(unittest.TestCase):
             icon_warning,
             slack_channel_main,
             "NOT_SET",
-            "AWS DataWorks Service Alerts - test_environment",
+            test_title,
         )
 
 
@@ -1356,7 +1358,7 @@ class TestRetriever(unittest.TestCase):
         tags_mock,
     ):
         input_message = {
-            "icon_override": ":aws:",
+            "icon_override": aws_icon,
             "slack_channel_override": "test-slack-channel-override"
         }
 
@@ -1369,10 +1371,10 @@ class TestRetriever(unittest.TestCase):
             "NOT_SET",
             "NOT_SET",
             "NOT_SET",
-            ":aws:",
+            aws_icon,
             "test-slack-channel-override",
             "NOT_SET",
-            "AWS DataWorks Service Alerts - test_environment",
+            test_title,
         )
     
 
@@ -1394,7 +1396,7 @@ class TestRetriever(unittest.TestCase):
             "active_days": "Monday",
             "do_not_alert_before": "0700",
             "do_not_alert_after": "1900",
-            "icon_override": ":aws:",
+            "icon_override": aws_icon,
             "slack_channel_override": "test-slack-channel-override",
             "log_with_here": "true",
             "title_text": "Test Title Text"
@@ -1409,40 +1411,11 @@ class TestRetriever(unittest.TestCase):
             "Monday",
             "0700",
             "1900",
-            ":aws:",
+            aws_icon,
             "test-slack-channel-override",
             "Test Title Text",
             "Test Alert",
             True,
-        )
-
-
-    @mock.patch(
-        "aws_cloudwatch_alerting_lambda.aws_cloudwatch_alerting.get_tags_for_cloudwatch_alarm"
-    )
-    @mock.patch(
-        "aws_cloudwatch_alerting_lambda.aws_cloudwatch_alerting.is_alarm_suppressed"
-    )
-    def test_config_custom_alarm_notification_returns_right_values_when_all_defaults_used(
-        self,
-        suppression_mock,
-        tags_mock,
-    ):
-        input_message = {}
-
-        custom_alarm_notification_returns_right_values(
-            self,
-            suppression_mock,
-            input_message,
-            "Medium",
-            "Warning",
-            "NOT_SET",
-            "NOT_SET",
-            "NOT_SET",
-            icon_warning,
-            slack_channel_main,
-            "NOT_SET",
-            "AWS DataWorks Service Alerts - test_environment",
         )
 
 

--- a/tests/test_aws_cloudwatch_alerting.py
+++ b/tests/test_aws_cloudwatch_alerting.py
@@ -1357,7 +1357,7 @@ class TestRetriever(unittest.TestCase):
     ):
         input_message = {
             "icon_override": aws_icon,
-            "slack_channel_override": "test-slack-channel-override"
+            "slack_channel_override": "test-slack-channel-override",
         }
 
         custom_alarm_notification_returns_right_values(

--- a/tests/test_aws_cloudwatch_alerting.py
+++ b/tests/test_aws_cloudwatch_alerting.py
@@ -1356,13 +1356,8 @@ class TestRetriever(unittest.TestCase):
         tags_mock,
     ):
         input_message = {
-<<<<<<< HEAD
             "icon_override": aws_icon,
             "slack_channel_override": "test-slack-channel-override"
-=======
-            "icon_override": ":aws:",
-            "slack_channel_override": "test-slack-channel-override",
->>>>>>> f7f8a2c6de30adfe46b0bd578f6b387275d7528b
         }
 
         custom_alarm_notification_returns_right_values(

--- a/tests/test_aws_cloudwatch_alerting.py
+++ b/tests/test_aws_cloudwatch_alerting.py
@@ -1315,6 +1315,137 @@ class TestRetriever(unittest.TestCase):
         self.assertEqual(expected_result, actual_result)
 
 
+    @mock.patch(
+        "aws_cloudwatch_alerting_lambda.aws_cloudwatch_alerting.get_tags_for_cloudwatch_alarm"
+    )
+    @mock.patch(
+        "aws_cloudwatch_alerting_lambda.aws_cloudwatch_alerting.is_alarm_suppressed"
+    )
+    def test_config_custom_alarm_notification_returns_right_values_when_all_defaults_used(
+        self,
+        suppression_mock,
+        tags_mock,
+    ):
+        input_message = {}
+
+        custom_alarm_notification_returns_right_values(
+            self,
+            suppression_mock,
+            input_message,
+            "Medium",
+            "Warning",
+            "NOT_SET",
+            "NOT_SET",
+            "NOT_SET",
+            icon_warning,
+            slack_channel_main,
+            "NOT_SET",
+            "AWS DataWorks Service Alerts - test_environment",
+        )
+
+
+    @mock.patch(
+        "aws_cloudwatch_alerting_lambda.aws_cloudwatch_alerting.get_tags_for_cloudwatch_alarm"
+    )
+    @mock.patch(
+        "aws_cloudwatch_alerting_lambda.aws_cloudwatch_alerting.is_alarm_suppressed"
+    )
+    def test_config_custom_alarm_notification_returns_right_values_when_overrides_used(
+        self,
+        suppression_mock,
+        tags_mock,
+    ):
+        input_message = {
+            "icon_override": ":aws:",
+            "slack_channel_override": "test-slack-channel-override"
+        }
+
+        custom_alarm_notification_returns_right_values(
+            self,
+            suppression_mock,
+            input_message,
+            "Medium",
+            "Warning",
+            "NOT_SET",
+            "NOT_SET",
+            "NOT_SET",
+            ":aws:",
+            "test-slack-channel-override",
+            "NOT_SET",
+            "AWS DataWorks Service Alerts - test_environment",
+        )
+    
+
+    @mock.patch(
+        "aws_cloudwatch_alerting_lambda.aws_cloudwatch_alerting.get_tags_for_cloudwatch_alarm"
+    )
+    @mock.patch(
+        "aws_cloudwatch_alerting_lambda.aws_cloudwatch_alerting.is_alarm_suppressed"
+    )
+    def test_config_custom_alarm_notification_returns_right_values_when_all_values_passed_in(
+        self,
+        suppression_mock,
+        tags_mock,
+    ):
+        input_message = {
+            "severity": "Low",
+            "notification_type": "Information",
+            "slack_username": "Test Alert",
+            "active_days": "Monday",
+            "do_not_alert_before": "0700",
+            "do_not_alert_after": "1900",
+            "icon_override": ":aws:",
+            "slack_channel_override": "test-slack-channel-override",
+            "log_with_here": "true",
+            "title_text": "Test Title Text"
+        }
+
+        custom_alarm_notification_returns_right_values(
+            self,
+            suppression_mock,
+            input_message,
+            "Low",
+            "Information",
+            "Monday",
+            "0700",
+            "1900",
+            ":aws:",
+            "test-slack-channel-override",
+            "Test Title Text",
+            "Test Alert",
+            True,
+        )
+
+
+    @mock.patch(
+        "aws_cloudwatch_alerting_lambda.aws_cloudwatch_alerting.get_tags_for_cloudwatch_alarm"
+    )
+    @mock.patch(
+        "aws_cloudwatch_alerting_lambda.aws_cloudwatch_alerting.is_alarm_suppressed"
+    )
+    def test_config_custom_alarm_notification_returns_right_values_when_all_defaults_used(
+        self,
+        suppression_mock,
+        tags_mock,
+    ):
+        input_message = {}
+
+        custom_alarm_notification_returns_right_values(
+            self,
+            suppression_mock,
+            input_message,
+            "Medium",
+            "Warning",
+            "NOT_SET",
+            "NOT_SET",
+            "NOT_SET",
+            icon_warning,
+            slack_channel_main,
+            "NOT_SET",
+            "AWS DataWorks Service Alerts - test_environment",
+        )
+
+
 def custom_cloudwatch_alarm_notification_returns_right_values(
     self,
     tags_mock,
@@ -1382,6 +1513,80 @@ def custom_cloudwatch_alarm_notification_returns_right_values(
                         "type": "mrkdwn",
                         "text": f"*{trigger_time_field_title}*: {state_updated_output_string}",
                     },
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*{severity_field_title}*: {expected_severity}",
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*{type_field_title}*: {expected_type}",
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*{active_days_field_title}*: {expected_active_days}",
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*{skip_before_field_title}*: {expected_skip_before}",
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*{skip_after_field_title}*: {expected_skip_after}",
+                    },
+                ],
+            },
+        ],
+    }
+
+    self.assertEqual(expected_payload, actual_payload)
+
+
+def custom_alarm_notification_returns_right_values(
+    self,
+    suppression_mock,
+    input_message,
+    expected_severity,
+    expected_type,
+    expected_active_days,
+    expected_skip_before,
+    expected_skip_after,
+    expected_icon,
+    expected_slack_channel,
+    expected_title_text,
+    expected_username,
+    expected_here_tag=False,
+
+):
+    self.maxDiff = None
+
+    aws_cloudwatch_alerting.is_alarm_suppressed.return_value = False
+
+    actual_payload = (
+        aws_cloudwatch_alerting.custom_notification(
+            input_message, region, {}
+        )
+    )
+    suppression_mock.assert_called_once()
+
+    expected_title = f'*TEST_ENVIRONMENT*: "_{expected_title_text}_" in eu-test-2'
+    if expected_here_tag:
+        expected_title = f'@here *TEST_ENVIRONMENT*: "_{expected_title_text}_" in eu-test-2'
+
+    expected_payload = {
+        "username": expected_username,
+        "icon_emoji": expected_icon,
+        "channel": expected_slack_channel,
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": expected_title,
+                },
+            },
+            {
+                "type": "context",
+                "elements": [
                     {
                         "type": "mrkdwn",
                         "text": f"*{severity_field_title}*: {expected_severity}",


### PR DESCRIPTION
Allow us to pass in custom notifications that go to slack via an sqs messages to the monitoring queues, making it a lot easier to notify in slack for things like HTME and Snappy